### PR TITLE
Correcting bug with SPI communication  mask

### DIFF
--- a/src/BMP280.cpp
+++ b/src/BMP280.cpp
@@ -52,7 +52,7 @@ namespace BMP280
     {
         uint8_t buffer[3] = {0x00, 0x00, 0x00};
         int32_t result = 0;
-        uint8_t readRegister = reg |= 0b1000000; // AND with 0b1000000 for read operation in SPI comunication.
+        uint8_t readRegister = reg |= _SPI_COMM_MASK ; // OR with reg because R='1' bit in SPI read operation
         if (burst == true)
         {
             // Read 3 register one after another
@@ -95,7 +95,7 @@ namespace BMP280
         #ifdef DEBUG_REGISTER
         printf("REGISTER - value to be set: %i\n", config);
         #endif
-        uint8_t data[2] = {(reg &= 0b01111111), config}; // OR with reg because R='0' bit in SPI write operation
+        uint8_t data[2] = {(reg &= ~_SPI_COMM_MASK ), config}; // OR with reg because R='0' bit in SPI write operation
         gpio_put(_cs, false);
         spi_write_blocking(_spiInst, data, 2);
         gpio_put(_cs, true);
@@ -124,7 +124,7 @@ namespace BMP280
     /// @return Value of specified register.
     uint8_t BMP280::readRegister(uint8_t reg)
     {
-        uint8_t data = (reg | 0b10000000);
+        uint8_t data = (reg | _SPI_COMM_MASK ); // OR with reg because R='1' bit in SPI read operation
         uint8_t buffer = 0;
         gpio_put(_cs, false);
         spi_write_blocking(_spiInst, &data, 1);

--- a/src/BMP280.hpp
+++ b/src/BMP280.hpp
@@ -63,6 +63,7 @@ namespace BMP280{
         double readPressure(int unit = 0);
         double getPressure(int unit = 0) const;
     private:
+        static constexpr uint8_t _SPI_COMM_MASK = 0x80; /**< SPI communication mask*/
         spi_inst_t *_spiInst;
         uint _cs;
         uint8_t _chipID;


### PR DESCRIPTION
Hi 

I think there is a bug on line 55,  BMP.cpp 
`uint8_t readRegister = reg |= 0b1000000; // AND with 0b1000000 for read operation in SPI comunication.
`
Should be 0x80 not 0x40,  missing a zero.

regards 